### PR TITLE
Correct to native button style on kari

### DIFF
--- a/web/static/css/danmaku.css
+++ b/web/static/css/danmaku.css
@@ -1,16 +1,20 @@
 .vjs-control.vjs-danmaku-control {
 	float: right;
 	margin-top: -24px;
-	margin-right: 50px;
-	width: 0px;
+	width: 100px;
 }
 
 .danmaku-menu-switcher-button {
 	border: 0;
-	background: black;
+	background: transparent;
 	color: white;
-	width: 90px;
 	outline: none;
+	text-shadow: 0 0 1px #000,0 0 2px #000, 0 0 5px #000;
+}
+
+.danmaku-menu-switcher-button:hover {
+	cursor: pointer;
+	text-shadow: 0 0 1em white;
 }
 
 .danmaku-composer {


### PR DESCRIPTION
Fixed: Button text warpped to next line. It is increased from 90px to 100px
Fixed: The button overlapped with the fill-control button
Enhancement: Makes the button looks more like a native control style
